### PR TITLE
Improve responsiveness

### DIFF
--- a/src/MainAppContent.js
+++ b/src/MainAppContent.js
@@ -34,12 +34,12 @@ export const MainAppContent = ({ user }) => {
       <header className="bg-white shadow-md sticky top-0 z-30">
         <nav className="container mx-auto px-4 py-3 flex flex-wrap justify-between items-center gap-4">
           <div className="text-xl sm:text-2xl font-bold text-indigo-700">Datenprodukt Planer</div>
-          <div className="flex items-center space-x-2 sm:space-x-3">
-            <NavLink pageName="personen">Personen</NavLink>
-            <NavLink pageName="datenprodukte">Datenprodukte</NavLink>
-            <NavLink pageName="rollen">Rollen</NavLink>
-            <NavLink pageName="skills">Skills</NavLink> {/* NEU */}
-            <NavLink pageName="auswertungen">Auswertungen</NavLink>
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <NavLink pageName="personen">Personen</NavLink>
+              <NavLink pageName="datenprodukte">Datenprodukte</NavLink>
+              <NavLink pageName="rollen">Rollen</NavLink>
+              <NavLink pageName="skills">Skills</NavLink> {/* NEU */}
+              <NavLink pageName="auswertungen">Auswertungen</NavLink>
             <button onClick={() => setShowChangePasswordModal(true)} className="px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100" title="Passwort ändern">Passwort ändern</button>
             <button onClick={handleLogout} className="px-3 py-2 rounded-md text-sm font-medium text-red-600 hover:bg-red-100" title="Abmelden">Logout</button>
           </div>

--- a/src/components/ExcelUploadModal.js
+++ b/src/components/ExcelUploadModal.js
@@ -72,7 +72,7 @@ export const ExcelUploadModal = ({ isOpen, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-gray-800 bg-opacity-75 flex justify-center items-center z-50 p-4" onClick={onClose}>
-        <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col p-6" onClick={e => e.stopPropagation()}>
+        <div className="bg-white rounded-lg shadow-xl w-full sm:max-w-2xl max-h-[90vh] flex flex-col p-6" onClick={e => e.stopPropagation()}>
             <h2 className="text-2xl font-semibold text-gray-800 mb-4">Personen per Excel importieren</h2>
             
             <div className="bg-blue-50 border border-blue-200 p-4 rounded-md mb-6 text-sm text-blue-800">

--- a/src/components/auth/ChangePasswordModal.js
+++ b/src/components/auth/ChangePasswordModal.js
@@ -33,7 +33,7 @@ export const ChangePasswordModal = ({ isOpen, onClose }) => {
 
     return (
         <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50 p-4" onClick={onClose}>
-            <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+            <div className="bg-white p-6 rounded-lg shadow-xl w-full sm:max-w-md" onClick={e => e.stopPropagation()}>
                 <h2 className="text-2xl font-semibold text-gray-700 mb-6">Passwort ändern</h2>
                 <form onSubmit={handleSubmit} className="space-y-4">
                     <div>

--- a/src/components/ui/ConfirmModal.js
+++ b/src/components/ui/ConfirmModal.js
@@ -5,7 +5,7 @@ export const ConfirmModal = ({ isOpen, message, onConfirm, onCancel, confirmText
     if (!isOpen) return null;
     return (
         <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50 p-4">
-            <div className="relative p-6 bg-white w-full max-w-md m-auto flex-col flex rounded-lg shadow-xl">
+            <div className="relative p-6 bg-white w-full sm:max-w-md m-auto flex-col flex rounded-lg shadow-xl">
                 <h3 className="text-xl font-semibold mb-4">{title}</h3>
                 <div className="text-md mb-6">{message}</div>
                 <div className="flex justify-end space-x-3">

--- a/src/pages/AuthPage.js
+++ b/src/pages/AuthPage.js
@@ -31,7 +31,7 @@ const AuthPage = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="w-full max-w-md p-8 bg-white rounded-2xl shadow-lg">
+    <div className="w-full max-w-md p-6 sm:p-8 bg-white rounded-2xl shadow-lg">
         <h2 className="text-2xl font-bold mb-6 text-center">{resetMode ? 'Passwort vergessen' : 'Login'}</h2>
 
         <input

--- a/src/pages/RollenVerwaltung.js
+++ b/src/pages/RollenVerwaltung.js
@@ -28,7 +28,7 @@ export const RollenVerwaltung = () => {
                     <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded-md shadow-sm hover:bg-indigo-700">Hinzufügen</button>
                 </form>
             </div>
-            <div className="bg-white shadow-md rounded-lg overflow-hidden">
+            <div className="bg-white shadow-md rounded-lg overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                         <tr>

--- a/src/pages/SkillsVerwaltung.js
+++ b/src/pages/SkillsVerwaltung.js
@@ -69,7 +69,7 @@ export const SkillsVerwaltung = () => {
                 </form>
             </div>
 
-            <div className="bg-white shadow-md rounded-lg overflow-hidden">
+            <div className="bg-white shadow-md rounded-lg overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                         <tr>


### PR DESCRIPTION
## Summary
- tweak padding in `AuthPage`
- allow horizontal scroll for role and skill tables
- add responsive widths to modals
- wrap navigation items on small screens

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684991a733a483278e54ac1cfd3fea6c