### PR TITLE
Add Firebase error overlay

### DIFF
--- a/src/components/auth/ChangePasswordModal.js
+++ b/src/components/auth/ChangePasswordModal.js
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { updatePassword } from 'firebase/auth';
 import { auth } from '../../firebase/config';
+import { ErrorOverlay } from '../ui/ErrorOverlay';
 
 export const ChangePasswordModal = ({ isOpen, onClose }) => {
     const [newPassword, setNewPassword] = useState('');
@@ -44,7 +45,6 @@ export const ChangePasswordModal = ({ isOpen, onClose }) => {
                         <label htmlFor="confirm-password" className="block text-sm font-medium text-gray-700">Neues Passwort bestätigen</label>
                         <input id="confirm-password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md"/>
                     </div>
-                    {error && <p className="text-sm text-red-500">{error}</p>}
                     {success && <p className="text-sm text-green-600">{success}</p>}
                     <div className="flex justify-end space-x-3 pt-4">
                         <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border rounded-md text-sm">Abbrechen</button>
@@ -52,6 +52,7 @@ export const ChangePasswordModal = ({ isOpen, onClose }) => {
                     </div>
                 </form>
             </div>
+            <ErrorOverlay message={error} onClose={() => setError('')} />
         </div>
     );
 };

--- a/src/components/ui/ErrorOverlay.js
+++ b/src/components/ui/ErrorOverlay.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export const ErrorOverlay = ({ message, onClose }) => {
+  if (!message) return null;
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="text-red-600 mb-4 break-words">{message}</p>
+        <div className="text-right">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/context/DataProvider.js
+++ b/src/context/DataProvider.js
@@ -1,5 +1,6 @@
 import React, { useState, createContext, useContext, useEffect, useCallback } from 'react';
 import { db, appId } from '../firebase/config';
+import { ErrorOverlay } from '../components/ui/ErrorOverlay';
 import {
   collection,
   doc,
@@ -89,6 +90,7 @@ export const DataProvider = ({ children, isReadOnly }) => {
       loading, error, setError
     }}>
       {children}
+      <ErrorOverlay message={error} onClose={() => setError(null)} />
     </DataContext.Provider>
   );
 };

--- a/src/pages/AuthPage.js
+++ b/src/pages/AuthPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { auth } from '../firebase/config';
 import { signInWithEmailAndPassword, sendPasswordResetEmail } from 'firebase/auth';
+import { ErrorOverlay } from '../components/ui/ErrorOverlay';
 
 const AuthPage = () => {
   const [email, setEmail] = useState('');
@@ -75,7 +76,7 @@ const AuthPage = () => {
         </p>
 
         {message && <p className="mt-4 text-green-600 text-center">{message}</p>}
-        {error && <p className="mt-4 text-red-600 text-center">{error}</p>}
+        <ErrorOverlay message={error} onClose={() => setError('')} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `ErrorOverlay` component
- display overlay for global errors in `DataProvider`
- show overlay in `AuthPage` and `ChangePasswordModal`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499b8665848327b48bedea70ee5ce4