### PR TITLE
Fix: Höhenbegrenzung bei aktiven Datenprodukten im Dashboard entfernt

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -654,7 +654,7 @@ const Dashboard = ({ onNavigate }) => {
                   <span className="text-sm font-medium text-gray-900 dark:text-white">Live</span>
                   <span className="text-xs text-gray-400">{products.live.length}</span>
                 </div>
-                <div className="p-2 max-h-48 overflow-y-auto">
+                <div className="p-2">
                   {products.live.slice(0, 6).map(p => (
                     <button
                       key={p.id}
@@ -675,7 +675,7 @@ const Dashboard = ({ onNavigate }) => {
                   <span className="text-sm font-medium text-gray-900 dark:text-white">In Entwicklung</span>
                   <span className="text-xs text-gray-400">{products.inDev.length}</span>
                 </div>
-                <div className="p-2 max-h-48 overflow-y-auto">
+                <div className="p-2">
                   {products.inDev.slice(0, 6).map(p => (
                     <button
                       key={p.id}


### PR DESCRIPTION
- max-h-48 von Live- und In-Entwicklung-Boxen entfernt
- Alle Einträge sind jetzt ohne Scrollen sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the max height and internal scrolling from the Live and In Development lists on the dashboard. Items are now visible without an inner scrollbar.

<sup>Written for commit 64da57218c449af10f23b45d4dd6d5124bc160b1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

